### PR TITLE
added notification into Offer/delete

### DIFF
--- a/src/UI/SnackBar/SnackBar.tsx
+++ b/src/UI/SnackBar/SnackBar.tsx
@@ -1,0 +1,13 @@
+import { notification } from 'antd';
+
+export type NotificationType = 'success' | 'info' | 'warning' | 'error';
+
+export default function showSnackBar(text:string, type: NotificationType='info') {
+  notification[type]({
+    message: text,
+    showProgress: true,
+    pauseOnHover: true,
+    placement: 'bottom',
+    // description:text,
+  })
+}

--- a/src/components/TableList/TableList.tsx
+++ b/src/components/TableList/TableList.tsx
@@ -5,6 +5,7 @@ import { offersAPI } from '../../store/services/offers.service';
 import styles from './tableListItem.module.scss';
 import { useState } from 'react';
 import BackdropCreateOfferForm from '../BackdropForm/BackdropCreateOfferForm';
+import showSnackBar from '../../UI/SnackBar/SnackBar';
 
 type TableList = {
   farmerId: number;
@@ -21,8 +22,11 @@ function TableList({ farmerId }: TableList) {
   });
 
   const handleDeleteOffer = async (id: number) => {
-    await deleteOffer({ offerId: id });
-    await refetch();
+    const res = await deleteOffer({ offerId: id });
+    if (res?.data) {
+      showSnackBar('The Offer was deleted');
+      await refetch();
+    }
   };
 
   const handleActivate = async (checked: boolean, offer: Offer) => {


### PR DESCRIPTION
- Added showSnackBar function
- Show snack bar in case of successful delete of an Offer in the Farmer's profile

Didn't find any more appropriate places for such a message right now. It looks like a good option for displaying error messages in case of some issues with DB for example. 

Closes #97 